### PR TITLE
Featuer/add dynamodb

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Para visualizar os endpoints disponíveis na aplicação basta acessar o swagger
 
 
 ## Desenvolvimento
+
+Para executar a aplicação localmente sem depender de recursos externos à máquina a aplicação deve rodar com a variável de ambiente `SPRING_PROFILES_ACTIVE` com valor **diferente** de `production` ou **vazia**.
+
+
 ### Executando somente dependências
 
 Para executar somente dependências externas (Mysql, RabbitMQ, etc) da aplicação para o ambiente de desevolvimento local basta executar o comando abaixo:
@@ -39,6 +43,16 @@ docker-compose -f docker-compose-without-application.yml up --build
 ```
 
 A aplicação será exposta na porta 8080.
+
+### Localstack
+A aplicação está com o dynamodb configurado no localstack para simular a AWS localmente.
+Os recursos estão sendo criados ao iniciar a imagem do localstack através do arquivo [init-aws.sh](config/localstack/init-aws.sh).
+
+Para listar recursos do localstack use o comando `aws` com o parâmetro `--endpoint-url=http://localhost:4566`, como no exemplo abaixo:
+
+```bash
+aws --endpoint-url=http://localhost:4566 dynamodb list-tables
+```
 
 ### Versionamento de libs gradle
 
@@ -54,7 +68,7 @@ Para acessar esse relatório gerado acesse o caminho `build/reports/jacoco/codeC
 
 ![img.png](static/jacoco_report_example.png)
 
-## Executando aplicação completa com docker
+### Executando aplicação completa com docker
 
 Execute o comando abaixo para iniciar os containers com a base de dados e executar a aplicação localmente.
 

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -11,3 +11,5 @@ springdoc.api-docs.path=/swagger.json
 springdoc.swagger-ui.path=/swagger
 server.servlet.encoding.charset=UTF-8
 
+
+dynamodb.tablename=tf-clients-table

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,6 +85,6 @@ tasks.test {
 
 sonarqube {
 	properties {
-		property("sonar.exclusions", "**/entity/**")
+		property("sonar.exclusions", "**/entity/**, **/*Configuration.java")
 	}
 }

--- a/config/localstack/init-aws.sh
+++ b/config/localstack/init-aws.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+awslocal dynamodb create-table \
+   --table-name tf-clients-table \
+   --attribute-definitions AttributeName=cpf,AttributeType=S \
+   --key-schema AttributeName=cpf,KeyType=HASH \
+   --provisioned-throughput ReadCapacityUnits=2,WriteCapacityUnits=2

--- a/docker-compose-without-application.yml
+++ b/docker-compose-without-application.yml
@@ -12,20 +12,21 @@ services:
       - '3306:3306'
     expose:
       - '3306'
-#  localstack:
-#    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_cloud}"
-#    image: localstack/localstack
-#    network_mode: bridge
-#    ports:
-#      - "127.0.0.1:4510-4530:4510-4530"
-#      - "127.0.0.1:4566:4566"
-#      - "127.0.0.1:4571:4571"
-#    environment:
-#      - AWS_DEFAULT_REGION=us-east-1
-#      - AWS_ACCESS_KEY_ID=fiap
-#      - AWS_SECRET_ACCESS_KEY=fiap
-#      - DEFAULT_REGION=us-east-1
-#      - SERVICES=dynamodb
-#    volumes:
-#      - "${TMPDIR:-/tmp}/localstack:/tmp/localstack"
-#      - "/var/run/docker.sock:/var/run/docker.sock"
+  localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_cloud}"
+    image: localstack/localstack
+    network_mode: bridge
+    ports:
+      - "127.0.0.1:4510-4530:4510-4530"
+      - "127.0.0.1:4566:4566"
+      - "127.0.0.1:4571:4571"
+    environment:
+      - AWS_DEFAULT_REGION=us-east-1
+      - AWS_ACCESS_KEY_ID=fiap
+      - AWS_SECRET_ACCESS_KEY=fiap
+      - DEFAULT_REGION=us-east-1
+      - SERVICES=dynamodb
+    volumes:
+      - "./config/localstack/init-aws.sh:/etc/localstack/init/ready.d/init-aws.sh"
+      - "${TMPDIR:-/tmp}/localstack:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose-without-application.yml
+++ b/docker-compose-without-application.yml
@@ -12,3 +12,20 @@ services:
       - '3306:3306'
     expose:
       - '3306'
+#  localstack:
+#    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_cloud}"
+#    image: localstack/localstack
+#    network_mode: bridge
+#    ports:
+#      - "127.0.0.1:4510-4530:4510-4530"
+#      - "127.0.0.1:4566:4566"
+#      - "127.0.0.1:4571:4571"
+#    environment:
+#      - AWS_DEFAULT_REGION=us-east-1
+#      - AWS_ACCESS_KEY_ID=fiap
+#      - AWS_SECRET_ACCESS_KEY=fiap
+#      - DEFAULT_REGION=us-east-1
+#      - SERVICES=dynamodb
+#    volumes:
+#      - "${TMPDIR:-/tmp}/localstack:/tmp/localstack"
+#      - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,24 @@ services:
       - '3306:3306'
     expose:
       - '3306'
+  localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_cloud}"
+    image: localstack/localstack
+    network_mode: bridge
+    ports:
+      - "127.0.0.1:4510-4530:4510-4530"
+      - "127.0.0.1:4566:4566"
+      - "127.0.0.1:4571:4571"
+    environment:
+      - AWS_DEFAULT_REGION=us-east-1
+      - AWS_ACCESS_KEY_ID=fiap
+      - AWS_SECRET_ACCESS_KEY=fiap
+      - DEFAULT_REGION=us-east-1
+      - SERVICES=dynamodb
+    volumes:
+      - "./config/localstack/init-aws.sh:/etc/localstack/init/ready.d/init-aws.sh"
+      - "${TMPDIR:-/tmp}/localstack:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
   application:
     build: .
     depends_on:

--- a/gateway/build.gradle.kts
+++ b/gateway/build.gradle.kts
@@ -6,5 +6,9 @@ dependencies {
     implementation(rootProject.libs.flyway.mysql)
     implementation(rootProject.libs.spring.boot.starter.data.jpa)
     implementation(rootProject.libs.hibernate.validator)
+
+
+    implementation(rootProject.libs.aws.dynamodb.enhanced)
+
     runtimeOnly(rootProject.libs.mysql.connector)
 }

--- a/gateway/src/main/java/com/fiap/burger/gateway/client/gateway/DefaultClientGateway.java
+++ b/gateway/src/main/java/com/fiap/burger/gateway/client/gateway/DefaultClientGateway.java
@@ -35,7 +35,7 @@ public class DefaultClientGateway implements ClientGateway {
     @Transactional
     public Client save(Client client) {
         Client persisted = clientDAO.save(ClientJPA.toJPA(client)).toEntity();
-        clientCpfGateway.save(client.getCpf(), client.getId());
+        clientCpfGateway.save(persisted.getCpf(), persisted.getId());
         return persisted;
     }
 

--- a/gateway/src/main/java/com/fiap/burger/gateway/client/gateway/DefaultClientGateway.java
+++ b/gateway/src/main/java/com/fiap/burger/gateway/client/gateway/DefaultClientGateway.java
@@ -3,7 +3,9 @@ package com.fiap.burger.gateway.client.gateway;
 import com.fiap.burger.entity.client.Client;
 import com.fiap.burger.gateway.client.dao.ClientDAO;
 import com.fiap.burger.gateway.client.model.ClientJPA;
+import com.fiap.burger.usecase.adapter.gateway.ClientCpfGateway;
 import com.fiap.burger.usecase.adapter.gateway.ClientGateway;
+import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
@@ -14,6 +16,9 @@ public class DefaultClientGateway implements ClientGateway {
 
     @Autowired
     private ClientDAO clientDAO;
+
+    @Autowired
+    private ClientCpfGateway clientCpfGateway;
 
     @Override
     public Client findById(Long id) {
@@ -27,8 +32,11 @@ public class DefaultClientGateway implements ClientGateway {
     }
 
     @Override
+    @Transactional
     public Client save(Client client) {
-        return clientDAO.save(ClientJPA.toJPA(client)).toEntity();
+        Client persisted = clientDAO.save(ClientJPA.toJPA(client)).toEntity();
+        clientCpfGateway.save(client.getCpf(), client.getId());
+        return persisted;
     }
 
 }

--- a/gateway/src/main/java/com/fiap/burger/gateway/clientcpf/gateway/DefaultClientCpfGateway.java
+++ b/gateway/src/main/java/com/fiap/burger/gateway/clientcpf/gateway/DefaultClientCpfGateway.java
@@ -1,0 +1,43 @@
+package com.fiap.burger.gateway.clientcpf.gateway;
+
+import com.fiap.burger.gateway.clientcpf.model.ClientCpfModel;
+import com.fiap.burger.usecase.adapter.gateway.ClientCpfGateway;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+@Repository
+public class DefaultClientCpfGateway implements ClientCpfGateway {
+
+    @Value("${dynamodb.tablename}")
+    private String tableName;
+    private final DynamoDbClient dynamoDbClient =
+        DynamoDbClient.builder()
+            .region(Region.US_EAST_1)
+            .credentialsProvider(ProfileCredentialsProvider.create())
+            .build();
+    private final DynamoDbEnhancedClient enhancedClient =
+        DynamoDbEnhancedClient.builder()
+            .dynamoDbClient(dynamoDbClient)
+            .build();
+
+    @Override
+    public void save(String cpf, Long clientId) {
+        getTable().putItem(new ClientCpfModel(cpf, clientId));
+    }
+
+    @Override
+    public Long findByCpf(String cpf) {
+        return getTable().getItem(Key.builder().partitionValue(cpf).build()).getId();
+    }
+
+    private DynamoDbTable<ClientCpfModel> getTable() {
+        return enhancedClient.table(tableName, TableSchema.fromBean(ClientCpfModel.class));
+    }
+}

--- a/gateway/src/main/java/com/fiap/burger/gateway/clientcpf/gateway/DefaultClientCpfGateway.java
+++ b/gateway/src/main/java/com/fiap/burger/gateway/clientcpf/gateway/DefaultClientCpfGateway.java
@@ -2,6 +2,7 @@ package com.fiap.burger.gateway.clientcpf.gateway;
 
 import com.fiap.burger.gateway.clientcpf.model.ClientCpfModel;
 import com.fiap.burger.usecase.adapter.gateway.ClientCpfGateway;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
@@ -15,29 +16,22 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 @Repository
 public class DefaultClientCpfGateway implements ClientCpfGateway {
 
-    @Value("${dynamodb.tablename}")
-    private String tableName;
-    private final DynamoDbClient dynamoDbClient =
-        DynamoDbClient.builder()
-            .region(Region.US_EAST_1)
-            .credentialsProvider(ProfileCredentialsProvider.create())
-            .build();
-    private final DynamoDbEnhancedClient enhancedClient =
-        DynamoDbEnhancedClient.builder()
-            .dynamoDbClient(dynamoDbClient)
-            .build();
+    private DynamoDbEnhancedClient enhancedClient;
+    private DynamoDbTable<ClientCpfModel> table;
 
+    DefaultClientCpfGateway(DynamoDbEnhancedClient enhancedClient, @Value("${dynamodb.tablename}") String tableName) {
+        this.enhancedClient = enhancedClient;
+        this.table = enhancedClient.table(tableName, TableSchema.fromBean(ClientCpfModel.class));
+    }
     @Override
     public void save(String cpf, Long clientId) {
-        getTable().putItem(new ClientCpfModel(cpf, clientId));
+        table.putItem(new ClientCpfModel(cpf, clientId));
     }
 
     @Override
     public Long findByCpf(String cpf) {
-        return getTable().getItem(Key.builder().partitionValue(cpf).build()).getId();
+        return table.getItem(Key.builder().partitionValue(cpf).build()).getId();
     }
 
-    private DynamoDbTable<ClientCpfModel> getTable() {
-        return enhancedClient.table(tableName, TableSchema.fromBean(ClientCpfModel.class));
-    }
+
 }

--- a/gateway/src/main/java/com/fiap/burger/gateway/clientcpf/gateway/DefaultClientCpfGateway.java
+++ b/gateway/src/main/java/com/fiap/burger/gateway/clientcpf/gateway/DefaultClientCpfGateway.java
@@ -2,16 +2,12 @@ package com.fiap.burger.gateway.clientcpf.gateway;
 
 import com.fiap.burger.gateway.clientcpf.model.ClientCpfModel;
 import com.fiap.burger.usecase.adapter.gateway.ClientCpfGateway;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 @Repository
 public class DefaultClientCpfGateway implements ClientCpfGateway {

--- a/gateway/src/main/java/com/fiap/burger/gateway/clientcpf/model/ClientCpfModel.java
+++ b/gateway/src/main/java/com/fiap/burger/gateway/clientcpf/model/ClientCpfModel.java
@@ -1,0 +1,35 @@
+package com.fiap.burger.gateway.clientcpf.model;
+
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class ClientCpfModel {
+
+    private String cpf;
+    private Long id;
+
+    public ClientCpfModel(){}
+
+    public ClientCpfModel(String cpf, Long id) {
+        this.cpf = cpf;
+        this.id = id;
+    }
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("cpf")
+    public String getCpf() { return this.cpf; }
+
+    public Long getId() { return this.id; }
+
+    public void setCpf(String cpf) { this.cpf = cpf;  }
+
+    public void setId(Long id) { this.id = id; }
+
+    @Override
+    public String toString() {
+        return "Customer [cpf=" + cpf + ", id=" + id + "]";
+    }
+}

--- a/gateway/src/main/java/com/fiap/burger/gateway/clientcpf/model/ClientCpfModel.java
+++ b/gateway/src/main/java/com/fiap/burger/gateway/clientcpf/model/ClientCpfModel.java
@@ -1,6 +1,7 @@
 package com.fiap.burger.gateway.clientcpf.model;
 
 
+import java.util.Objects;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
@@ -18,6 +19,8 @@ public class ClientCpfModel {
         this.id = id;
     }
 
+
+
     @DynamoDbPartitionKey
     @DynamoDbAttribute("cpf")
     public String getCpf() { return this.cpf; }
@@ -27,6 +30,18 @@ public class ClientCpfModel {
     public void setCpf(String cpf) { this.cpf = cpf;  }
 
     public void setId(Long id) { this.id = id; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ClientCpfModel that)) return false;
+        return Objects.equals(getCpf(), that.getCpf()) && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getCpf(), getId());
+    }
 
     @Override
     public String toString() {

--- a/gateway/src/main/java/com/fiap/burger/gateway/misc/DynamoDbConfiguration.java
+++ b/gateway/src/main/java/com/fiap/burger/gateway/misc/DynamoDbConfiguration.java
@@ -1,0 +1,25 @@
+package com.fiap.burger.gateway.misc;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+@Configuration
+public class DynamoDbConfiguration {
+
+    @Bean
+    public DynamoDbEnhancedClient dynamoDbEnhancedClient(@Value("${dynamodb.tablename}") String tableName) {
+        DynamoDbClient dynamoDbClient =
+            DynamoDbClient.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(ProfileCredentialsProvider.create())
+                .build();
+        return DynamoDbEnhancedClient.builder()
+                .dynamoDbClient(dynamoDbClient)
+                .build();
+    }
+}

--- a/gateway/src/main/java/com/fiap/burger/gateway/misc/DynamoDbConfiguration.java
+++ b/gateway/src/main/java/com/fiap/burger/gateway/misc/DynamoDbConfiguration.java
@@ -1,9 +1,14 @@
 package com.fiap.burger.gateway.misc;
 
+import com.fiap.burger.usecase.misc.profiles.Production;
+import java.net.URI;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -12,6 +17,8 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 public class DynamoDbConfiguration {
 
     @Bean
+    @Production
+    @Primary
     public DynamoDbEnhancedClient dynamoDbEnhancedClient(@Value("${dynamodb.tablename}") String tableName) {
         DynamoDbClient dynamoDbClient =
             DynamoDbClient.builder()
@@ -21,5 +28,18 @@ public class DynamoDbConfiguration {
         return DynamoDbEnhancedClient.builder()
                 .dynamoDbClient(dynamoDbClient)
                 .build();
+    }
+
+    @Bean
+    public DynamoDbEnhancedClient localStackDynamoDbEnhancedClient(@Value("${dynamodb.tablename}") String tableName) {
+        DynamoDbClient dynamoDbClient =
+            DynamoDbClient.builder()
+                .region(Region.US_EAST_1)
+                .endpointOverride(URI.create("http://localhost:4566"))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("fiap", "fiap")))
+                .build();
+        return DynamoDbEnhancedClient.builder()
+            .dynamoDbClient(dynamoDbClient)
+            .build();
     }
 }

--- a/gateway/src/test/java/com/fiap/burger/gateway/client/gateway/DefaultClientGatewayTest.java
+++ b/gateway/src/test/java/com/fiap/burger/gateway/client/gateway/DefaultClientGatewayTest.java
@@ -3,6 +3,7 @@ package com.fiap.burger.gateway.client.gateway;
 import com.fiap.burger.gateway.client.dao.ClientDAO;
 import com.fiap.burger.gateway.misc.ClientBuilder;
 import com.fiap.burger.gateway.misc.ClientJPABuilder;
+import com.fiap.burger.usecase.adapter.gateway.ClientCpfGateway;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -18,6 +19,9 @@ class DefaultClientGatewayTest {
 
     @Mock
     ClientDAO clientDAO;
+
+    @Mock
+    ClientCpfGateway clientCpfGateway;
 
     @InjectMocks
     DefaultClientGateway gateway;
@@ -64,6 +68,7 @@ class DefaultClientGatewayTest {
         var expected = new ClientBuilder().withId(1L).build();
 
         when(clientDAO.save(any())).thenReturn(clientJPA);
+        doNothing().when(clientCpfGateway).save(expected.getCpf(), expected.getId());
 
         var actual = gateway.save(client);
 

--- a/gateway/src/test/java/com/fiap/burger/gateway/clientcpf/gateway/DefaultClientCpfGatewayTest.java
+++ b/gateway/src/test/java/com/fiap/burger/gateway/clientcpf/gateway/DefaultClientCpfGatewayTest.java
@@ -1,0 +1,66 @@
+package com.fiap.burger.gateway.clientcpf.gateway;
+
+import com.fiap.burger.gateway.misc.ClientCpfModelBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DefaultClientCpfGatewayTest {
+
+    @Mock
+    DynamoDbEnhancedClient client;
+
+    @Mock
+    DynamoDbTable table;
+
+    DefaultClientCpfGateway gateway;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        when(client.table(any(), any())).thenReturn(table);
+
+        gateway = new DefaultClientCpfGateway(client, "tableName");
+    }
+
+
+    @Test
+    void shouldFindByCpf() {
+        var cpf = "12345678909";
+        var expectedId = 1L;
+        var clientCpfModel = new ClientCpfModelBuilder().withCpf(cpf).withId(expectedId).build();
+
+        when(table.getItem(Key.builder().partitionValue(cpf).build())).thenReturn(clientCpfModel);
+
+        var actual = gateway.findByCpf(cpf);
+
+        assertEquals(expectedId, actual);
+
+        verify(table, times(1)).getItem(Key.builder().partitionValue(cpf).build());
+    }
+
+    @Test
+    void shouldSaveClientCpf() {
+        var cpf = "12345678909";
+        var id = 1L;
+        var clientCpfModel = new ClientCpfModelBuilder().withCpf(cpf).withId(id).build();
+
+        doNothing().when(table).putItem(clientCpfModel);
+
+        gateway.save(cpf, id);
+
+        verify(table, times(1)).putItem(clientCpfModel);
+    }
+}

--- a/gateway/src/test/java/com/fiap/burger/gateway/clientcpf/model/ClientCpfModelTest.java
+++ b/gateway/src/test/java/com/fiap/burger/gateway/clientcpf/model/ClientCpfModelTest.java
@@ -1,0 +1,42 @@
+package com.fiap.burger.gateway.clientcpf.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClientCpfModelTest {
+
+    @Test
+    void shouldUseSettersCorrectly() {
+        var newCpf = "123456";
+        var newId = 123L;
+
+        var actual = new ClientCpfModel("oldCpf", 1L);
+        actual.setCpf(newCpf);
+        actual.setId(newId);
+
+        assertEquals(actual.getCpf(), newCpf);
+        assertEquals(actual.getId(), newId);
+    }
+
+    @Test
+    void shouldCreateInstanceCorrectly() {
+        var cpf = "123456";
+        var id = 1L;
+
+        var actual = new ClientCpfModel(cpf, id);
+
+        assertEquals(actual.getCpf(), cpf);
+        assertEquals(actual.getId(), id);
+    }
+
+    @Test
+    void shouldMatchToString() {
+        var expected = "Customer [cpf=123456, id=1]";
+        var clientCpf = new ClientCpfModel("123456", 1L);
+
+        var actual = clientCpf.toString();
+
+        assertEquals(expected, actual);
+    }
+}

--- a/gateway/src/test/java/com/fiap/burger/gateway/misc/ClientCpfModelBuilder.java
+++ b/gateway/src/test/java/com/fiap/burger/gateway/misc/ClientCpfModelBuilder.java
@@ -1,0 +1,27 @@
+package com.fiap.burger.gateway.misc;
+
+import com.fiap.burger.gateway.client.model.ClientJPA;
+import com.fiap.burger.gateway.clientcpf.model.ClientCpfModel;
+import java.time.LocalDateTime;
+
+public class ClientCpfModelBuilder {
+
+    private Long id = 1L;
+
+    private String cpf = "68203895077";
+
+    public ClientCpfModelBuilder withId(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public ClientCpfModelBuilder withCpf(String cpf) {
+        this.cpf = cpf;
+        return this;
+    }
+
+    public ClientCpfModel build() {
+        return new ClientCpfModel(cpf, id);
+    }
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ mysql-connector = "8.0.33"
 hibernate = "6.2.4.Final"
 hibernate-validator = "8.0.0.Final"
 openapi = "2.1.0"
+aws = "2.21.10"
 
 [libraries]
 flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
@@ -18,3 +19,6 @@ mysql-connector = { module = "com.mysql:mysql-connector-j", version.ref = "mysql
 hibernate = { module = "org.hibernate.orm:hibernate-core", version.ref = "hibernate" }
 hibernate-validator = { module = "org.hibernate.validator:hibernate-validator", version.ref = "hibernate" }
 openapi = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "openapi" }
+aws-dynamodb = { module = "software.amazon.awssdk:dynamodb", version.ref = "aws" }
+aws-dynamodb-enhanced = { module = "software.amazon.awssdk:dynamodb-enhanced", version.ref = "aws" }
+

--- a/usecase/src/main/java/com/fiap/burger/usecase/adapter/gateway/ClientCpfGateway.java
+++ b/usecase/src/main/java/com/fiap/burger/usecase/adapter/gateway/ClientCpfGateway.java
@@ -1,0 +1,10 @@
+package com.fiap.burger.usecase.adapter.gateway;
+
+
+public interface ClientCpfGateway {
+
+    void save(String cpf, Long clientId);
+
+    Long findByCpf(String cpf);
+
+}

--- a/usecase/src/main/java/com/fiap/burger/usecase/misc/profiles/Production.java
+++ b/usecase/src/main/java/com/fiap/burger/usecase/misc/profiles/Production.java
@@ -1,0 +1,10 @@
+package com.fiap.burger.usecase.misc.profiles;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.context.annotation.Profile;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Profile("production")
+public @interface Production {
+}


### PR DESCRIPTION
Adicionando integração com dynamodb para salvar id do usuário e CPF.
Incluído localstack para rodar dynamodb sem depender da AWS.
Atualizado o readme.
Adicionando profile de `production`.
