### PR TITLE
fix: Remove profiles credentials

### DIFF
--- a/gateway/src/main/java/com/fiap/burger/gateway/misc/DynamoDbConfiguration.java
+++ b/gateway/src/main/java/com/fiap/burger/gateway/misc/DynamoDbConfiguration.java
@@ -23,7 +23,6 @@ public class DynamoDbConfiguration {
         DynamoDbClient dynamoDbClient =
             DynamoDbClient.builder()
                 .region(Region.US_EAST_1)
-                .credentialsProvider(ProfileCredentialsProvider.create())
                 .build();
         return DynamoDbEnhancedClient.builder()
                 .dynamoDbClient(dynamoDbClient)


### PR DESCRIPTION
Removendo ProfileCredentialsProvider para tentar parar com o erro de `software.amazon.awssdk.core.exception.SdkClientException: Profile file contained no credentials for profile 'default': ProfileFile(profilesAndSectionsMap=[])`